### PR TITLE
Set up flake8 and fix style issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/main.py
+++ b/main.py
@@ -1,29 +1,33 @@
+import os
+import tkinter as tk
 import tkinter.font as font
-from tkinter import *
 from tkinter import messagebox
-from serial import *
-from settings import *
+import serial
+import settings
 
 # Versionsnummer des Programms
 __version__ = '0.1i'
 
 # COM-Port definieren
-ser = Serial(com_port, baudrate, timeout=1)
+ser = serial.Serial(settings.com_port, settings.baudrate, timeout=1)
 
 # Versuchen, COM-Port zu öffnen
 try:
     ser.open()
-except:
+except serial.SerialException:
     try:
         ser.close()
         ser.open()
     except Exception as e:
-        messagebox.showerror("Fehler", f"Konnte COM-Port nicht öffnen: {str(e)}")
+        messagebox.showerror(
+            "Fehler", f"Konnte COM-Port nicht öffnen: {str(e)}"
+        )
 
 # GUI erstellen
-root = Tk()
+root = tk.Tk()
 root.title("QO-100 v" + __version__)
 root.resizable(width=False, height=False)
+
 
 def execute_cat_commands(commands: dict):
     cmd_list = ''
@@ -32,65 +36,80 @@ def execute_cat_commands(commands: dict):
     try:
         ser.write(bytes(cmd_list.encode('ascii')))
     except Exception as e:
-        messagebox.showerror("Fehler", f"Konnte Befehl nicht senden: {str(e)}")
+        messagebox.showerror(
+            "Fehler", f"Konnte Befehl nicht senden: {str(e)}"
+        )
+
 
 # Prozedur für QO-100 Button
 def qo100():
-    execute_cat_commands(qo100_cat)
+    execute_cat_commands(settings.qo100_cat)
     label2.config(text="QO-100 Betrieb geschaltet!")
-    console_button.config(state=ACTIVE)
-    qo100_button.config(state=DISABLED)
-    normal_button.config(state=ACTIVE)
+    console_button.config(state=tk.ACTIVE)
+    qo100_button.config(state=tk.DISABLED)
+    normal_button.config(state=tk.ACTIVE)
+
 
 # Prozedur für Normal Button
 def normal():
-    execute_cat_commands(normal_cat)
+    execute_cat_commands(settings.normal_cat)
     label2.config(text="NORMAL Betrieb geschaltet!")
-    console_button.config(state=DISABLED)
-    normal_button.config(state=DISABLED)
-    qo100_button.config(state=ACTIVE)
+    console_button.config(state=tk.DISABLED)
+    normal_button.config(state=tk.DISABLED)
+    qo100_button.config(state=tk.ACTIVE)
+
 
 # Prozedur für Start der SDR-Console
 def sdr_console():
-    console_button.config(state=DISABLED)
-    normal_button.config(state=DISABLED)
-    qo100_button.config(state=DISABLED)
+    console_button.config(state=tk.DISABLED)
+    normal_button.config(state=tk.DISABLED)
+    qo100_button.config(state=tk.DISABLED)
     label2.config(text="SDR-Console geöffnet! - Bitte manuell schließen!")
     try:
-        os.system(sdr_console_path)
+        os.system(settings.sdr_console_path)
     except Exception as e:
-        messagebox.showerror("Fehler", f"Konnte SDR-Console nicht öffnen: {str(e)}")
-    console_button.config(state=ACTIVE)
-    qo100_button.config(state=DISABLED)
-    normal_button.config(state=ACTIVE)
+        messagebox.showerror(
+            "Fehler", f"Konnte SDR-Console nicht öffnen: {str(e)}"
+        )
+    console_button.config(state=tk.ACTIVE)
+    qo100_button.config(state=tk.DISABLED)
+    normal_button.config(state=tk.ACTIVE)
+
 
 tabellenbreite = 3
 
 # Copyright-Label
-label1 = Label(root, text="QO-100 Steuerung v" + __version__)
-label1_2 = Label(root, text="Software: © 08/2023 by DO1FFE\nHardware: © 08/2021 by DO7GJ")
+label1 = tk.Label(root, text="QO-100 Steuerung v" + __version__)
+label1_2 = tk.Label(
+    root,
+    text="Software: © 08/2023 by DO1FFE\nHardware: © 08/2021 by DO7GJ",
+)
 myFont = font.Font(size=20)
 label1['font'] = myFont
 label1.grid(row=0, column=0, columnspan=tabellenbreite)
 label1_2.grid(row=1, column=0, columnspan=tabellenbreite)
 
 # Button für Normal-Betrieb
-normal_button = Button(root, text="Normal", pady=10, padx=50, command=normal)
-normal_button.config(state=DISABLED)
+normal_button = tk.Button(
+    root, text="Normal", pady=10, padx=50, command=normal
+)
+normal_button.config(state=tk.DISABLED)
 normal_button.grid(row=2, column=0, pady=10, padx=10)
 
 # Button für QO-100 Betrieb
-qo100_button = Button(root, text="QO-100", pady=10, padx=50, command=qo100)
-qo100_button.config(state=ACTIVE)
+qo100_button = tk.Button(root, text="QO-100", pady=10, padx=50, command=qo100)
+qo100_button.config(state=tk.ACTIVE)
 qo100_button.grid(row=2, column=1, padx=10)
 
 # Button für SDR-Console starten
-console_button = Button(root, text="SDR-Console", pady=10, padx=50, command=sdr_console)
-console_button.config(state=DISABLED)
+console_button = tk.Button(
+    root, text="SDR-Console", pady=10, padx=50, command=sdr_console
+)
+console_button.config(state=tk.DISABLED)
 console_button.grid(row=2, column=2, padx=10)
 
 # Hinweistexte
-label2 = Label(root, text="Bitte Betriebsmodus wählen!")
+label2 = tk.Label(root, text="Bitte Betriebsmodus wählen!")
 label2.grid(row=3, column=0, columnspan=tabellenbreite, pady=10)
 
 # Programmschleife
@@ -100,4 +119,6 @@ root.mainloop()
 try:
     ser.close()
 except Exception as e:
-    messagebox.showerror("Fehler", f"Konnte COM-Port nicht schließen: {str(e)}")
+    messagebox.showerror(
+        "Fehler", f"Konnte COM-Port nicht schließen: {str(e)}"
+    )

--- a/settings.py
+++ b/settings.py
@@ -13,16 +13,16 @@ qo100_cat = {
     'CT00': 'CTCSS AUS',
     'MD02': 'MODE auf USB',
     'PC005': 'Sendeleistung auf 5W',
-    'EX140010' : 'Maximale Sendeleistung auf 10W begrenzen',
-    'LK1' : 'LOCK einschalten',
-    'MG030' : 'MIC GAIN auf 30'
+    'EX140010': 'Maximale Sendeleistung auf 10W begrenzen',
+    'LK1': 'LOCK einschalten',
+    'MG030': 'MIC GAIN auf 30'
 }
 
 normal_cat = {
     # CAT-Befehl :  Beschreibung
     'MC003': 'Memory Channel 003',
     'PC010': 'Sendeleistung auf 10W',
-    'EX140020' : 'Maximale Sendeleistung auf 20W begrenzen',
-    'LK1' : 'LOCK einschalten',
-    'MG070' : 'MIC GAIN auf 70'
+    'EX140020': 'Maximale Sendeleistung auf 20W begrenzen',
+    'LK1': 'LOCK einschalten',
+    'MG070': 'MIC GAIN auf 70'
 }


### PR DESCRIPTION
## Summary
- add flake8 configuration
- drop star imports and clean up imports
- handle SerialException explicitly
- break long lines
- update settings with no whitespace before colons

## Testing
- `flake8`
- `python3 -m py_compile main.py settings.py`

------
https://chatgpt.com/codex/tasks/task_e_684195722edc8321a725383e9648ad85